### PR TITLE
Remove ast from file before cloning

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -24,6 +24,7 @@
         return;
       }
       ast = module.file.ast;
+      delete module.file.ast;
       if (!module.hasDefine) {
         defineReturnStatement = b.returnStatement(module.exports ? b.identifier(module.exports) : null);
         if (options.wrapShim && module.isShimmed) {

--- a/src/export.coffee
+++ b/src/export.coffee
@@ -17,6 +17,7 @@ module.exports = fixModule = (options = {}) ->
       return
 
     ast = module.file.ast
+    delete module.file.ast
 
     if not module.hasDefine
 


### PR DESCRIPTION
- Deletes the ast key from the file after it is used as a local var in
  the exports module
- Prevents performance regression when the file is cloned in vinyl.

Vinyl 0.3.0 introduced deep cloning of file properties. When contents of
ast are included, it takes a conderable amount of time to clone it.
These contents are used as a local variable and not needed.

This was detected when building a project with d3.js, which apparently
has a complex ast. Time drastically reduced from 1.5 minutes to 18s.

Vinyl Change:
https://github.com/wearefractal/vinyl/commit/e493187b3f2fd1485077f09e73e669407ac077d3#diff-168726dbe96b3ce427e7fedce31bb0bcR51
