### PR TITLE
added test for external dependencies

### DIFF
--- a/test/fixtures/deps/config.js
+++ b/test/fixtures/deps/config.js
@@ -1,0 +1,9 @@
+(function () {
+    'use strict';
+
+    require.config({
+        paths: {
+            extra: 'deps/extra/extra'
+        }
+    });
+}());

--- a/test/fixtures/deps/deps/extra/extra.js
+++ b/test/fixtures/deps/deps/extra/extra.js
@@ -1,0 +1,7 @@
+(function () {
+    'use strict';
+
+    define(['./lib/helper'], function (helper) {
+        return 'extra:' + helper;
+    });
+}());

--- a/test/fixtures/deps/deps/extra/lib/helper.js
+++ b/test/fixtures/deps/deps/extra/lib/helper.js
@@ -1,0 +1,7 @@
+(function () {
+    'use strict';
+
+    define(function () {
+        return 'helper';
+    });
+}());

--- a/test/fixtures/deps/src/index.js
+++ b/test/fixtures/deps/src/index.js
@@ -1,0 +1,7 @@
+(function () {
+    'use strict';
+
+    define(['extra'], function (extra) {
+        return 'hello:' + extra;
+    });
+}());

--- a/test/index_test.coffee
+++ b/test/index_test.coffee
@@ -472,6 +472,22 @@ describe "config file", ->
 
 
 
+describe "deps", ->
+
+  it "should compile", (done) ->
+
+    checkExpectedFiles(
+      ["index.js"]
+      vinylfs.src(["#{dir}/fixtures/**/*.js"], {base: "#{dir}/fixtures/deps/src"})
+        .pipe(amdOptimize(
+          "index"
+          configFile : "#{dir}/fixtures/deps/config.js"
+        ))
+      done
+    )
+
+
+
 describe "special paths", ->
 
   it "should ignore requirejs plugins", (done) ->


### PR DESCRIPTION
Added a test that uses config.js to specify where external dependencies are. Directory structure:
- src
  - index.js - depends on `extra`
- deps
  - extra
    - extra.js
    - lib
      - helper.js
- config.js - `{paths: { extra: "deps/extra/extra" } }`

I relatively new to `gulp`, `requirejs` and CoffeeScript, so this test may need to be modified. The intent of the test is to emulate a relatively complex `bower` + `requirejs` setup.
