### PR TITLE
Brute-force implementation of requirejs-text plugin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,20 +69,21 @@
   };
 
   defaultLoader = function(fileBuffer, options) {
-    return function(name, callback) {
-      var file;
+    return function(name, callback, asPlainFile) {
+      var addJs, file;
+      addJs = (!asPlainFile) && '.js' || '';
       if (options.baseUrl && (file = _.detect(fileBuffer, {
-        path: path.resolve(options.baseUrl, name + ".js")
+        path: path.resolve(options.baseUrl, name + addJs)
       }))) {
         return callback(null, file);
       } else if (file = _.detect(fileBuffer, {
-        relative: path.join(options.baseUrl, name + ".js")
+        relative: path.join(options.baseUrl, name + addJs)
       })) {
         return callback(null, file);
       } else if (options.loader) {
         return options.loader(name, callback);
       } else {
-        return module.exports.loader()(path.join(options.baseUrl, name + ".js"), callback);
+        return module.exports.loader()(path.join(options.baseUrl, name + addJs), callback);
       }
     };
   };

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -34,15 +34,20 @@
   })();
 
   module.exports = traceModule = function(startModuleName, config, allModules, fileLoader, callback) {
-    var emitModule, foundModuleNames, resolveInlinedModule, resolveModule, resolveModuleFileName, resolveModuleName, resolveModules;
+    var emitModule, foundModuleNames, resolveInlinedModule, resolveModule, resolveModuleFileName, resolveModuleName, resolveModules, textFiles;
     if (allModules == null) {
       allModules = [];
     }
     foundModuleNames = [];
+    textFiles = {};
     resolveModuleName = function(moduleName, relativeTo) {
-      var relativeToFileName;
+      var isText, relativeToFileName;
       if (relativeTo == null) {
         relativeTo = "";
+      }
+      isText = moduleName.indexOf('text!') !== -1;
+      if (isText) {
+        moduleName = moduleName.replace('text!', '');
       }
       relativeToFileName = resolveModuleFileName(relativeTo);
       if (moduleName[0] === ".") {
@@ -50,6 +55,9 @@
       }
       if (config.map && config.map[relativeTo] && config.map[relativeTo][moduleName]) {
         moduleName = config.map[relativeTo][moduleName];
+      }
+      if (isText) {
+        textFiles[moduleName] = true;
       }
       return moduleName;
     };
@@ -82,7 +90,7 @@
       ], callback);
     };
     resolveModule = function(moduleName, callback) {
-      var fileName, module;
+      var fileName, isTextFile, module;
       module = _.detect(allModules, {
         name: moduleName
       });
@@ -104,9 +112,10 @@
         foundModuleNames.push(moduleName);
       }
       module = null;
+      isTextFile = !!textFiles[moduleName];
       async.waterfall([
         function(callback) {
-          return fileLoader(fileName, callback);
+          return fileLoader(fileName, callback, isTextFile);
         }, function(file, callback) {
           if (arguments.length === 1) {
             callback = file;
@@ -119,6 +128,9 @@
           }
         }, function(file, callback) {
           file.stringContents = file.contents.toString("utf8");
+          if (isTextFile) {
+            file.stringContents = 'define(function(){ return ' + JSON.stringify(file.stringContents) + '; });';
+          }
           module = new Module(moduleName, file);
           return callback(null, file);
         }, parse.bind(null, config), function(file, definitions, callback) {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -70,16 +70,18 @@ mergeOptionsFile = (file, options = {}) ->
 
 defaultLoader = (fileBuffer, options) ->
 
-  return (name, callback) ->
+  return (name, callback, asPlainFile) ->
 
-    if options.baseUrl and file = _.detect(fileBuffer, path : path.resolve(options.baseUrl, name + ".js"))
+    addJs = (!asPlainFile) and '.js' or ''
+
+    if options.baseUrl and file = _.detect(fileBuffer, path : path.resolve(options.baseUrl, name + addJs))
       callback(null, file)
-    else if file = _.detect(fileBuffer, relative : path.join(options.baseUrl, name + ".js"))
+    else if file = _.detect(fileBuffer, relative : path.join(options.baseUrl, name + addJs))
       callback(null, file)
     else if options.loader
       options.loader(name, callback)
     else
-      module.exports.loader()(path.join(options.baseUrl, name + ".js"), callback)
+      module.exports.loader()(path.join(options.baseUrl, name + addJs), callback)
 
 
 

--- a/test/fixtures/core/plugin-text.js
+++ b/test/fixtures/core/plugin-text.js
@@ -1,0 +1,5 @@
+(function () {
+  define(["bar", "text!./text.html"], function (bar, test) {
+    console.log(bar, test);
+  });
+})();

--- a/test/fixtures/core/plugin.js
+++ b/test/fixtures/core/plugin.js
@@ -1,5 +1,5 @@
 (function () {
-  define(["bar", "text!foo"], function (test) {
+  define(["bar", "plugin!foo"], function (test) {
     console.log(test);
   });
 })();

--- a/test/fixtures/core/text.html
+++ b/test/fixtures/core/text.html
@@ -1,0 +1,1 @@
+<h1>This is text</h1>

--- a/test/index_test.coffee
+++ b/test/index_test.coffee
@@ -519,6 +519,24 @@ describe "special paths", ->
     )
 
 
+  it "should ignore requirejs plugins (except text)", (done) ->
+
+    content = ''
+
+    checkExpectedFiles(
+      ["bar.js", "text.html", "plugin-text.js"]
+      vinylfs.src("#{dir}/fixtures/core/*.*")
+        .pipe(amdOptimize("plugin-text"))
+      .on("data", (file) ->
+        #assert.equal(path.normalize(expectedFiles.shift()), file.relative)
+        if (file.relative == 'text.html')
+          content = file.contents.toString()
+      )
+      () ->
+        assert.equal(content, 'define(\'text.html\', [], function () {\n    return \'<h1>This is text</h1>\';\n});')
+        done()
+    )
+
   it "should ignore empty paths", (done) ->
 
     checkExpectedFiles(


### PR DESCRIPTION
I honestly don't think it is a best way to implement requirejs-text plugin, but it is something close enough. Should be OK for most cases.

As a proposal, you can build a queue of plugins where developers can intercept loading procedure for modules and do what they want with them. For example

``` js
amdOptimize('foo', {
    plugins: [text(), less(), typescript(), ...]
}
```

each plugin should provide the prefix to `resolveModuleName()` function, this prefix should trigger plugin execution later on in `defaultLoader()`. Default `js` loader should probably be one of available plugin (maybe last in the queue) so that `defaultLoader()` will remain abstract.
