### PR TITLE
Support usage of module shortcuts.

### DIFF
--- a/lib/trace.js
+++ b/lib/trace.js
@@ -41,13 +41,22 @@
     foundModuleNames = [];
     textFiles = {};
     resolveModuleName = function(moduleName, relativeTo) {
-      var isText, relativeToFileName;
+      var eligiblePath, isText, relativeToFileName, slashIdx;
       if (relativeTo == null) {
         relativeTo = "";
       }
       isText = moduleName.indexOf('text!') !== -1;
       if (isText) {
         moduleName = moduleName.replace('text!', '');
+      }
+      if (config.paths && !config.paths[moduleName]) {
+        slashIdx = moduleName.indexOf("/");
+        if (slashIdx > 0) {
+          eligiblePath = config.paths[moduleName.substr(0, slashIdx)];
+          if (eligiblePath) {
+            moduleName = eligiblePath + moduleName.substr(slashIdx);
+          }
+        }
       }
       relativeToFileName = resolveModuleFileName(relativeTo);
       if (moduleName[0] === ".") {

--- a/src/trace.coffee
+++ b/src/trace.coffee
@@ -34,6 +34,14 @@ module.exports = traceModule = (startModuleName, config, allModules = [], fileLo
     if (isText)
       moduleName = moduleName.replace('text!', '')
 
+    # Deal with module shortcuts
+    if config.paths and !config.paths[moduleName]
+      slashIdx = moduleName.indexOf("/")
+      if slashIdx > 0
+        eligiblePath = config.paths[moduleName.substr(0,slashIdx)];
+        if eligiblePath
+          moduleName =  eligiblePath + moduleName.substr(slashIdx)
+
     relativeToFileName = resolveModuleFileName(relativeTo)
 
     if moduleName[0] == "."

--- a/test/fixtures/shortcuts/config.js
+++ b/test/fixtures/shortcuts/config.js
@@ -1,0 +1,9 @@
+(function () {
+  "use strict";
+
+  require.config({
+    paths: {
+      "module": "path/to/module"
+    }
+  });
+}());

--- a/test/fixtures/shortcuts/index.js
+++ b/test/fixtures/shortcuts/index.js
@@ -1,0 +1,7 @@
+(function () {
+  "use strict";
+
+  define(["module/foo"], function (foo) {
+    return "hello:" + foo;
+  });
+}());

--- a/test/fixtures/shortcuts/path/to/module/foo.js
+++ b/test/fixtures/shortcuts/path/to/module/foo.js
@@ -1,0 +1,5 @@
+(function () {
+  define("foo", function(){
+    return "foo";
+  });
+})();

--- a/test/index_test.coffee
+++ b/test/index_test.coffee
@@ -208,6 +208,17 @@ describe "core", ->
       done
     )
 
+  it "should resolve module name shortcuts",  (done) ->
+    checkExpectedFiles(
+      ["path/to/module/foo.js", "index.js"]
+      vinylfs.src(["#{dir}/fixtures/shortcuts/**/*.js"], { base: "#{dir}/fixtures/shortcuts" })
+      .pipe(amdOptimize(
+          "index"
+          configFile : "#{dir}/fixtures/shortcuts/config.js"
+      ))
+      done
+    )
+
 
 describe "src", ->
 


### PR DESCRIPTION
I had a problem using amd-optimize because I was using some shortcuts to access to some module in my code.
In the config file I got some declaration like this :
```javascript
{
  paths : {
    "core" : "path/to/lib/core"
  }
}
```
So when I want to access to ```path/to/lib/core/MyModule.js``` I just need to use it like this:
```javascript
define("core/MyModule", function(myModule){
});
```
This is working with requireJS without optimization, but it was not working with amd-optimize.
I'm not sure it is a good way to use requireJS (even if it works). It is the first time I write code with coffee script. So, please, review my code before merging it.
