### PR TITLE
Prepend 'require', 'exports', and 'module' to deps list when CommonJS define() flavor is detected

### DIFF
--- a/src/parse.coffee
+++ b/src/parse.coffee
@@ -47,7 +47,7 @@ module.exports = parseRequireDefinitions = (config, file, callback) ->
           if node.arguments[0].type == "FunctionExpression" and
           node.arguments[0].params.length > 0
 
-            deps = []
+            deps = ['require', 'exports', 'module']
             walk.simple(node.arguments[0], CallExpression : (node) ->
               if node.callee.name == "require" or node.callee.name == "requirejs"
                 deps.push(node.arguments[0].value)


### PR DESCRIPTION
Proposed solution to #34:

When parsing a module definition like `define(function (require, exports, module) {})`, start with 'require', 'exports', and 'module' in the deps list instead of an empty deps list. This prevents parsed dependencies from being injected as the `require`, `exports`, and `module` arguments.