### PR TITLE
Allow local variables named `define` to be called **AST Feedback Wanted**

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -80,6 +80,7 @@
             method: "define",
             moduleName: moduleName,
             deps: deps != null ? deps : [],
+            argumentsLength: node["arguments"].length,
             node: node
           });
           isInsideDefine = true;

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -16,10 +16,10 @@
   util = require("./util");
 
   Module = (function() {
-    function Module(name, file, deps) {
-      this.name = name;
-      this.file = file;
-      this.deps = deps != null ? deps : [];
+    function Module(_at_name, _at_file, _at_deps) {
+      this.name = _at_name;
+      this.file = _at_file;
+      this.deps = _at_deps != null ? _at_deps : [];
       this.name = util.fixModuleName(this.name);
       this.isShallow = false;
       this.isShimmed = false;
@@ -144,7 +144,7 @@
           return callback(null, file);
         }, parse.bind(null, config), function(file, definitions, callback) {
           if (_.filter(definitions, function(def) {
-            return def.method === "define" && def.moduleName === void 0;
+            return def.method === "define" && def.moduleName === void 0 && def.argumentsLength > 0;
           }).length > 1) {
             callback(new Error("A module must not have more than one anonymous 'define' calls."));
             return;

--- a/lib/util.js
+++ b/lib/util.js
@@ -14,9 +14,9 @@
     depPrefix = prefix.replace("├", "|").replace("└", " ").replace(/─/g, " ");
     return currentModule.deps.forEach(function(depModule, i) {
       if (i + 1 < currentModule.deps.length) {
-        return printTree(depModule, "" + depPrefix + " ├──");
+        return printTree(depModule, depPrefix + " ├──");
       } else {
-        return printTree(depModule, "" + depPrefix + " └──");
+        return printTree(depModule, depPrefix + " └──");
       }
     });
   };

--- a/src/parse.coffee
+++ b/src/parse.coffee
@@ -71,6 +71,7 @@ module.exports = parseRequireDefinitions = (config, file, callback) ->
         method : "define"
         moduleName : moduleName
         deps : deps ? []
+        argumentsLength: node.arguments.length
         node : node
       )
 

--- a/src/trace.coffee
+++ b/src/trace.coffee
@@ -148,7 +148,7 @@ module.exports = traceModule = (startModuleName, config, allModules = [], fileLo
 
       (file, definitions, callback) ->
 
-        if _.filter(definitions, (def) -> return def.method == "define" and def.moduleName == undefined).length > 1
+        if _.filter(definitions, (def) -> return def.method == "define" and def.moduleName == undefined and def.argumentsLength > 0).length > 1
           callback(new Error("A module must not have more than one anonymous 'define' calls."))
           return
 

--- a/test/fixtures/errors/multiple_anonymous_defines.js
+++ b/test/fixtures/errors/multiple_anonymous_defines.js
@@ -1,0 +1,6 @@
+(function () {
+  define(function (test) {
+    define(function () {
+    });
+  });
+})();

--- a/test/index_test.coffee
+++ b/test/index_test.coffee
@@ -669,6 +669,16 @@ describe "errors", ->
     )
 
 
+  it "should throw an error on multiple anonymous define calls", (done) ->
+
+    amdOptimize.src(
+      "multiple_anonymous_defines"
+      baseUrl : "test/fixtures/errors"
+    ).on("error", (err) ->
+      assert.ok(util.isError(err))
+      done()
+    )
+
   it "should work with circular dependencies when exports is used"
   # , (done) ->
   #   # http://requirejs.org/docs/api.html#circular


### PR DESCRIPTION
- Calling a nested local variable named `define` no longer triggers the `A module must not have more than one anonymous 'define' calls.` as long as there are no arguments.

While using [FlightJS](https://github.com/flightjs/flight/blob/master/lib/component.js#L99), `amd-optimize` was throwing a false positive error when checking for anonymous `define` calls.

I do not know enough about how to detect this scenario with AST, so this my naive attempt. Is there a better way?