### PR TITLE
Change how configFile is loaded to allow for calls to require() in the file with the config, common for bootstrapping

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -1,5 +1,5 @@
 (function() {
-  var b, escodegen, fixModule, path, through, vinylSourcemapsApply, _;
+  var _, b, escodegen, fixModule, path, through, vinylSourcemapsApply;
 
   _ = require("lodash");
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 (function() {
-  var Readable, async, collectModules, defaultLoader, exportModule, firstChunk, fs, mergeOptionsFile, path, rjs, through, trace, util, vinylFs, _;
+  var Readable, _, async, collectModules, defaultLoader, exportModule, firstChunk, fs, mergeOptionsFile, path, rjs, through, trace, util, vinylFs;
 
   _ = require("lodash");
 
@@ -65,7 +65,7 @@
     if (options == null) {
       options = {};
     }
-    return _.merge({}, Function("var output,\n  requirejs = require = {\n    config : function (options) { output = options; }\n  },\n  define = function () {};\n" + (file.contents.toString("utf8")) + ";\nreturn output;")(), options);
+    return _.merge({}, Function("var output,\n  requirejs = require = function() {},\n  define = function () {};\nrequire.config = function (options) { output = options; };\n" + (file.contents.toString("utf8")) + ";\nreturn output;")(), options);
   };
 
   defaultLoader = function(fileBuffer, options) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,5 +1,5 @@
 (function() {
-  var acorn, escodegen, parseRequireDefinitions, valuesFromArrayExpression, walk, _;
+  var _, acorn, escodegen, parseRequireDefinitions, valuesFromArrayExpression, walk;
 
   _ = require("lodash");
 

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -1,5 +1,5 @@
 (function() {
-  var Module, VinylFile, async, fs, parse, path, traceModule, util, _;
+  var Module, VinylFile, _, async, fs, parse, path, traceModule, util;
 
   _ = require("lodash");
 
@@ -16,10 +16,10 @@
   util = require("./util");
 
   Module = (function() {
-    function Module(name, file, deps) {
+    function Module(name, file1, deps1) {
       this.name = name;
-      this.file = file;
-      this.deps = deps != null ? deps : [];
+      this.file = file1;
+      this.deps = deps1 != null ? deps1 : [];
       this.name = util.fixModuleName(this.name);
       this.isShallow = false;
       this.isShimmed = false;
@@ -154,8 +154,8 @@
           });
           return async.mapSeries(definitions, function(def, callback) {
             def.deps = def.deps.map(function(depName) {
-              var _ref;
-              return resolveModuleName(depName, (_ref = def.moduleName) != null ? _ref : moduleName);
+              var ref;
+              return resolveModuleName(depName, (ref = def.moduleName) != null ? ref : moduleName);
             });
             if (def.method === "define" && def.moduleName !== void 0 && def.moduleName !== moduleName) {
               async.waterfall([
@@ -173,8 +173,8 @@
         }, function(unflatModules, callback) {
           return callback(null, _.compact(_.flatten(unflatModules)));
         }, function(depModules, callback) {
-          var _ref;
-          (_ref = module.deps).push.apply(_ref, depModules);
+          var ref;
+          (ref = module.deps).push.apply(ref, depModules);
           module.isAnonymous = true;
           async.waterfall([
             function(callback) {
@@ -200,8 +200,8 @@
                 return callback(null, []);
               }
             }, function(depModules, callback) {
-              var _ref1;
-              (_ref1 = module.deps).push.apply(_ref1, depModules);
+              var ref1;
+              (ref1 = module.deps).push.apply(ref1, depModules);
               return callback(null, emitModule(module));
             }
           ], callback);

--- a/lib/util.js
+++ b/lib/util.js
@@ -14,9 +14,9 @@
     depPrefix = prefix.replace("├", "|").replace("└", " ").replace(/─/g, " ");
     return currentModule.deps.forEach(function(depModule, i) {
       if (i + 1 < currentModule.deps.length) {
-        return printTree(depModule, "" + depPrefix + " ├──");
+        return printTree(depModule, depPrefix + " ├──");
       } else {
-        return printTree(depModule, "" + depPrefix + " └──");
+        return printTree(depModule, depPrefix + " └──");
       }
     });
   };

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -57,10 +57,9 @@ mergeOptionsFile = (file, options = {}) ->
     {}
     Function("""
       var output,
-        requirejs = require = {
-          config : function (options) { output = options; }
-        },
+        requirejs = require = function() {},
         define = function () {};
+      require.config = function (options) { output = options; };
       #{file.contents.toString("utf8")};
       return output;
       """)()

--- a/test/fixtures/config/config.js
+++ b/test/fixtures/config/config.js
@@ -6,4 +6,6 @@
     }
   });
 
+  require([ "foo" ], function(foo) {});
+
 })();


### PR DESCRIPTION
I have a setup where I use index.js to do my config and bootstrapping so that I can have only one script tag. Using the configFile option would crash on my call to require( ["main"], function(main) {...}) since require isn't defined as a function when loading the config.