### PR TITLE
Added RequireJS json plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# amd-optimize [![Build Status](https://drone.io/github.com/scalableminds/amd-optimize/status.png)](https://drone.io/github.com/scalableminds/amd-optimize/latest)
+# amd-optimize 
+Modified from (https://github.com/scalableminds/amd-optimize) adding support for RequireJS json plugin support. One can now use 'json!<path to json file>' in a define and it will be imported as a parsed JSON object.
+
+# NOTE
+This repo will be deleted if / when a pull request is accepted by the original repo. 
 
 > An AMD ([RequireJS](http://requirejs.org/)) optimizer that's stream-friendly. Made for [gulp](http://gulpjs.com/). (WIP)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # amd-optimize 
-Modified from (https://github.com/scalableminds/amd-optimize) adding support for RequireJS json plugin support. One can now use 'json!<path to json file>' in a define and it will be imported as a parsed JSON object.
+Modified from (https://github.com/scalableminds/amd-optimize) adding support for RequireJS json plugin support. One can now use 'json!path/to/json/file.json' in a define and it will be imported as a parsed JSON object.
 
 # NOTE
 This repo will be deleted if / when a pull request is accepted by the original repo. 

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -34,20 +34,25 @@
   })();
 
   module.exports = traceModule = function(startModuleName, config, allModules, fileLoader, callback) {
-    var emitModule, foundModuleNames, resolveInlinedModule, resolveModule, resolveModuleFileName, resolveModuleName, resolveModules, textFiles;
+    var emitModule, foundModuleNames, jsonFiles, resolveInlinedModule, resolveModule, resolveModuleFileName, resolveModuleName, resolveModules, textFiles;
     if (allModules == null) {
       allModules = [];
     }
     foundModuleNames = [];
     textFiles = {};
+    jsonFiles = {};
     resolveModuleName = function(moduleName, relativeTo) {
-      var eligiblePath, isText, relativeToFileName, slashIdx;
+      var eligiblePath, isJson, isText, relativeToFileName, slashIdx;
       if (relativeTo == null) {
         relativeTo = "";
       }
       isText = moduleName.indexOf('text!') !== -1;
       if (isText) {
         moduleName = moduleName.replace('text!', '');
+      }
+      isJson = moduleName.indexOf('json!') !== -1;
+      if (isJson) {
+        moduleName = moduleName.replace('json!', '');
       }
       if (config.paths && !config.paths[moduleName]) {
         slashIdx = moduleName.indexOf("/");
@@ -67,6 +72,9 @@
       }
       if (isText) {
         textFiles[moduleName] = true;
+      }
+      if (isJson) {
+        jsonFiles[moduleName] = true;
       }
       return moduleName;
     };
@@ -99,7 +107,7 @@
       ], callback);
     };
     resolveModule = function(moduleName, callback) {
-      var fileName, isTextFile, module;
+      var fileName, isJsonFile, isTextFile, module;
       module = _.detect(allModules, {
         name: moduleName
       });
@@ -122,9 +130,10 @@
       }
       module = null;
       isTextFile = !!textFiles[moduleName];
+      isJsonFile = !!jsonFiles[moduleName];
       async.waterfall([
         function(callback) {
-          return fileLoader(fileName, callback, isTextFile);
+          return fileLoader(fileName, callback, isTextFile || isJsonFile);
         }, function(file, callback) {
           if (arguments.length === 1) {
             callback = file;
@@ -139,6 +148,9 @@
           file.stringContents = file.contents.toString("utf8");
           if (isTextFile) {
             file.stringContents = 'define(function(){ return ' + JSON.stringify(file.stringContents) + '; });';
+          }
+          if (isJsonFile) {
+            file.stringContents = 'define(function(){ return JSON.parse(' + JSON.stringify(file.stringContents) + '); });';
           }
           module = new Module(moduleName, file);
           return callback(null, file);


### PR DESCRIPTION
Hi Norman et al,

Thanks for amd-optimize! I added support for the RequireJS json plugin. It's handy to be able to define a json file and have it import as a json object versus having to use the text plugin and manually parse the text file.

The changes were seemingly minimal and I have verified that it works under a non-trivial gulp build process using amd-optimize. 