### PR TITLE
Fix: some define calls are misinterpreted

### DIFF
--- a/src/trace.coffee
+++ b/src/trace.coffee
@@ -164,7 +164,7 @@ module.exports = traceModule = (startModuleName, config, allModules = [], fileLo
 
       (file, definitions, callback) ->
 
-        if _.filter(definitions, (def) -> return def.method == "define" and def.moduleName == undefined and def.argumentsLength > 0).length > 1
+        if _.filter(definitions, (def) -> return def.method == "define" and def.moduleName == undefined and 0 < def.argumentsLength < 3).length > 1
           callback(new Error("A module must not have more than one anonymous 'define' calls."))
           return
 


### PR DESCRIPTION
Encountered this bug in aurelia-default-loader, which calls define somewhere but the moduleName is not recognized (it's dynamic).
`define` calls with 3 arguments are not anonymous and this condition fixes the issue I'm having.
